### PR TITLE
fix(openapi): Change OpenAPI metadata binding from `defineMetadata` to `mergeMetadata`

### DIFF
--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -45,7 +45,7 @@ export class RouterLoader {
 
     const name = stringHelpers.create(target.name).removeSuffix('Controller').toString()
 
-    OperationMetadataStorage.defineMetadata(
+    OperationMetadataStorage.mergeMetadata(
       target.prototype,
       {
         path: route.pattern,


### PR DESCRIPTION
Hello 👋

I'm proposing this fix for a problem I've encountered. Typically if you use the `@ApiOperation` decorator to define a description, it is not taken into account for some absolutely unknown reason. The same applies to `@ApiExcludeController`.

I've replaced `OperationMetadataStorage.defineMetadata(...)` by `OperationMetadataStorage.mergeMetadata(...)` since it supposedly overwrites additional configuration on an operation. This solved my problem. In my opinion, merge is preferable because in some cases it is necessary to define additional properties in the documentation.

I don't know if the problem is due to the fact that I'm using [@softwarecitadel/girouette](https://github.com/SoftwareCitadel/adonisjs-girouette) for route mapping, but it was tedious to use.
 
I remain at your disposal if you need any changes or further explanations!
Have nice day :)