### PR TITLE
feat(openapi): add config option to disable auto tags based on controller name

### DIFF
--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -3,15 +3,18 @@ import { HttpRouterService } from '@adonisjs/core/types'
 import { RouteJSON } from '@adonisjs/core/types/http'
 import { OperationMetadataStorage } from 'openapi-metadata/metadata'
 import { isConstructor } from './utils.js'
+import { OpenAPIConfig } from './types.js'
 import stringHelpers from '@adonisjs/core/helpers/string'
 
 export class RouterLoader {
   #router: HttpRouterService
   #logger: Logger
+  #config: OpenAPIConfig
 
-  constructor(router: HttpRouterService, logger: Logger) {
+  constructor(config: OpenAPIConfig, router: HttpRouterService, logger: Logger) {
     this.#router = router
     this.#logger = logger
+    this.#config = config
   }
 
   async importRouterController(route: RouteJSON): Promise<[Function, string] | undefined> {
@@ -50,7 +53,7 @@ export class RouterLoader {
       {
         path: route.pattern,
         methods: route.methods.filter((m) => m !== 'HEAD').map((r) => r.toLowerCase()) as any,
-        tags: [name],
+        tags: (this.#config.generateTags === undefined || this.#config.generateTags) ? [name] : [],
       },
       propertyKey
     )

--- a/packages/openapi/src/openapi.ts
+++ b/packages/openapi/src/openapi.ts
@@ -26,7 +26,7 @@ export class OpenAPI {
   ) {
     this.#router = router
     this.#logger = logger
-    this.#routerLoader = new RouterLoader(router, logger)
+    this.#routerLoader = new RouterLoader(config, router, logger)
     this.#isProduction = isProduction
     this.#config = config
   }

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -16,6 +16,12 @@ export type OpenAPIConfig = {
   ui: 'scalar' | 'swagger' | 'rapidoc'
 
   /**
+   * Does automatically generate tags for your routes
+   * based on the controller name. (Default: true)
+   */
+  generateTags?: boolean
+
+  /**
    * Additional controllers to load into your schema.
    */
   controllers?: GenerateDocumentParameters['controllers']


### PR DESCRIPTION
Hello again 😎

I've added an extra option in the config to disable the generation of automatic tags based on controller names.
This option remains enabled by default so as not to change the normal behavior of the package.

Have a nice day!