### PR TITLE
fix(openapi): Fix Path parameters in OpenAPI documentation to output as {id} instead of :id

### DIFF
--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -48,7 +48,7 @@ export class RouterLoader {
     OperationMetadataStorage.defineMetadata(
       target.prototype,
       {
-        path: route.pattern,
+        path: route.pattern.replaceAll(/:([^/]+)/g, '{$1}'),
         methods: route.methods.filter((m) => m !== 'HEAD').map((r) => r.toLowerCase()) as any,
         tags: [name],
       },

--- a/playgrounds/openapi/adonisrc.ts
+++ b/playgrounds/openapi/adonisrc.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     () => import('@adonisjs/core/commands'),
     () => import('@adonisjs/lucid/commands'),
     () => import('@adonisjs/bouncer/commands'),
-    () => import('@foadonis/crypt/commands')
+    // () => import('@foadonis/crypt/commands')
   ],
 
   /*

--- a/playgrounds/openapi/app/controllers/demo_controller.ts
+++ b/playgrounds/openapi/app/controllers/demo_controller.ts
@@ -1,5 +1,6 @@
 import User from '#models/user'
-import { ApiOperation, ApiResponse, ApiHeader } from '@foadonis/openapi/decorators'
+import { HttpContext } from '@adonisjs/core/http'
+import { ApiOperation, ApiResponse, ApiHeader, ApiParam } from '@foadonis/openapi/decorators'
 
 export default class DemoController {
   @ApiOperation({ summary: 'Generate a super cool thing' })
@@ -7,5 +8,11 @@ export default class DemoController {
   @ApiHeader({ name: 'hey' })
   async index() {
     console.log('hello worl')
+  }
+
+  @ApiOperation({ summary: 'Generate a super cool thing' })
+  @ApiParam({ name: 'id', description: 'The id of the thing to generate' })
+  async show({ params }: HttpContext) {
+    console.log(params.id)
   }
 }

--- a/playgrounds/openapi/start/routes.ts
+++ b/playgrounds/openapi/start/routes.ts
@@ -5,6 +5,7 @@ const DemoController = () => import('#controllers/demo_controller')
 const PostsController = () => import('#controllers/posts_controller')
 
 router.get('/users', [DemoController, 'index'])
+router.get('/users/:id', [DemoController, 'show'])
 router.resource('posts', PostsController)
 
 openapi.registerRoutes()


### PR DESCRIPTION
FIxes the following issue : #50 