### PR TITLE
Fix(shopkeeper): add subscription userId to handleCustomerSubscriptionUpdated

### DIFF
--- a/packages/shopkeeper/src/handlers/handle_customer_subscription_updated.ts
+++ b/packages/shopkeeper/src/handlers/handle_customer_subscription_updated.ts
@@ -13,6 +13,7 @@ export async function handleCustomerSubscriptionUpdated(
   let subscription = await user.related('subscriptions').query().where('stripeId', data.id).first()
   if (!subscription) {
     subscription = new shopkeeper.subscriptionModel()
+    subscription.userId = user.id
     subscription.stripeId = data.id
   }
 


### PR DESCRIPTION
I encountered this issue when Stripe was not sending events in sequence. When the handleCustomerSubscriptionUpdated webhook is triggered first, it results in a subscription with a null userId. Afterwards, the handleCustomerSubscriptionCreated webhook will look for a user with a subscription. This causes handleCustomerSubscriptionCreated to not find the subscription and attempt to create a new one, which results in a duplicate error for the stripeId.