### PR TITLE
feat(openapi): remove content-negotiation and AdonisJS to OpenAPI path conversion

### DIFF
--- a/.changeset/fast-islands-press.md
+++ b/.changeset/fast-islands-press.md
@@ -1,0 +1,13 @@
+---
+'@foadonis/openapi': minor
+---
+
+Remove content negotiation in favor of file extensions for documentation format.
+
+When registering OpenAPI routes you will now have 3 registered routes:
+
+- /api - returns the OpenAPI documentation UI
+- /api.json - returns the OpenAPI documentation in JSON format
+- /api.yaml - returns the OpenAPI documentation in YAML format
+
+The routes are named `openapi.html`, `openapi.json` and `openapi.yaml`.

--- a/.changeset/thick-islands-cover.md
+++ b/.changeset/thick-islands-cover.md
@@ -2,4 +2,5 @@
 '@foadonis/openapi': patch
 ---
 
-Automatically convert AdoniJS paths to OpenAPI complient paths
+Automatically convert AdonisJS paths to OpenAPI compliant paths
+For example `/users/:id` become `/users/{id}`.

--- a/.changeset/thick-islands-cover.md
+++ b/.changeset/thick-islands-cover.md
@@ -1,0 +1,5 @@
+---
+'@foadonis/openapi': patch
+---
+
+Automatically convert AdoniJS paths to OpenAPI complient paths

--- a/docs/content/docs/openapi/getting-started.mdx
+++ b/docs/content/docs/openapi/getting-started.mdx
@@ -91,7 +91,13 @@ openapi.registerRoutes()
 
 ### Access the documentation
 
-You can now head over your OpenAPI documentation at [http://localhost:3000/api](http://localhost:3000/api). It will welcome you with a beautiful documentation page of your api thanks to [Scalar](https://scalar.com).
+You can now head over your OpenAPI documentation at [http://localhost:3333/api](http://localhost:3333/api). It will welcome you with a beautiful documentation page of your api thanks to [Scalar](https://scalar.com).
+
+The following endpoints are available:
+
+- [/api](http://localhost:3333/api) - Displays the documentation UI
+- [/api.json](http://localhost:3333/api.json) - Returns the documentation in JSON format
+- [/api.yaml](http://localhost:3333/api.yaml) - Returns the documentation in YAML format
 
 <img
   src="/openapi/showcase.svg"

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -21,15 +21,78 @@
 
 <!-- automd:coverage -->
 
-![Coverage](https://img.shields.io/badge/coverage-62%25-orange)
+![Coverage](https://img.shields.io/badge/coverage-70%25-orange)
 
 <!-- /automd -->
 
 </div>
 
+## Features
+
+- **OpenAPI Compliant**: Automatically converts Adonis-style path parameters to OpenAPI-compliant format
+- **Seamless Integration**: Works with your existing AdonisJS routes without any configuration changes
+- **Standards Compliant**: Generated OpenAPI documentation passes validation in all OpenAPI tools and validators
+- **Advanced Parameter Support**: Handles regular, optional, and wildcard parameters according to AdonisJS routing rules
+
 ## Quickstart
 
-[Installation & Getting Started](https://friendsofadonis.github.io/docs/openapi/getting-started)
+[Installation & Getting Started](https://friendsofadonis.com/docs/openapi/getting-started)
+
+## Path Parameter Transformation
+
+This package automatically transforms your AdonisJS route patterns to OpenAPI-compliant format. Based on the [AdonisJS routing documentation](https://docs.adonisjs.com/guides/basics/routing), route patterns don't contain search parameters, and wildcard parameters can only appear at the end of the path.
+
+### Regular Parameters
+```typescript
+// Your AdonisJS routes
+router.get('/users/:id', [UsersController, 'show'])
+router.get('/posts/:postId/comments/:commentId', [CommentsController, 'index'])
+
+// Generated OpenAPI paths
+// /users/{id}
+// /posts/{postId}/comments/{commentId}
+```
+
+### Optional Parameters
+```typescript
+// AdonisJS optional parameters (with ?)
+router.get('/users/:id?', [UsersController, 'show'])
+router.get('/api/:version?/users/:id', [UsersController, 'index'])
+
+// Generated OpenAPI paths
+// /users/{id}
+// /api/{version}/users/{id}
+```
+
+### Wildcard Parameters
+```typescript
+// AdonisJS wildcard parameters (with *) - only at end of path
+router.get('/files/*', [FilesController, 'serve'])
+router.get('/users/:id/*', [FilesController, 'userFiles'])
+
+// Generated OpenAPI paths
+// /files{wildcard}
+// /users/{id}/{wildcard}
+```
+
+### Mixed Parameter Types
+```typescript
+// Complex routes with mixed parameter types
+router.get('/api/:version?/organizations/:orgId?/projects/:projectId/*', [ProjectsController, 'files'])
+
+// Generated OpenAPI path
+// /api/{version}/organizations/{orgId}/projects/{projectId}/{wildcard}
+```
+
+## AdonisJS Routing Rules
+
+This package follows the official AdonisJS routing conventions:
+
+- **Route patterns don't contain search parameters** - they're handled separately by the request object
+- **Wildcard parameters (*) can only appear at the end** of the path and capture all remaining segments
+- **Optional parameters use ? suffix** and can appear anywhere in the path
+- **Regular parameters use : prefix** and capture single path segments
+- **Trailing slashes are not part of route patterns** - they're handled by the router itself
 
 ## License
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -21,78 +21,15 @@
 
 <!-- automd:coverage -->
 
-![Coverage](https://img.shields.io/badge/coverage-70%25-orange)
+![Coverage](https://img.shields.io/badge/coverage-62%25-orange)
 
 <!-- /automd -->
 
 </div>
 
-## Features
-
-- **OpenAPI Compliant**: Automatically converts Adonis-style path parameters to OpenAPI-compliant format
-- **Seamless Integration**: Works with your existing AdonisJS routes without any configuration changes
-- **Standards Compliant**: Generated OpenAPI documentation passes validation in all OpenAPI tools and validators
-- **Advanced Parameter Support**: Handles regular, optional, and wildcard parameters according to AdonisJS routing rules
-
 ## Quickstart
 
-[Installation & Getting Started](https://friendsofadonis.com/docs/openapi/getting-started)
-
-## Path Parameter Transformation
-
-This package automatically transforms your AdonisJS route patterns to OpenAPI-compliant format. Based on the [AdonisJS routing documentation](https://docs.adonisjs.com/guides/basics/routing), route patterns don't contain search parameters, and wildcard parameters can only appear at the end of the path.
-
-### Regular Parameters
-```typescript
-// Your AdonisJS routes
-router.get('/users/:id', [UsersController, 'show'])
-router.get('/posts/:postId/comments/:commentId', [CommentsController, 'index'])
-
-// Generated OpenAPI paths
-// /users/{id}
-// /posts/{postId}/comments/{commentId}
-```
-
-### Optional Parameters
-```typescript
-// AdonisJS optional parameters (with ?)
-router.get('/users/:id?', [UsersController, 'show'])
-router.get('/api/:version?/users/:id', [UsersController, 'index'])
-
-// Generated OpenAPI paths
-// /users/{id}
-// /api/{version}/users/{id}
-```
-
-### Wildcard Parameters
-```typescript
-// AdonisJS wildcard parameters (with *) - only at end of path
-router.get('/files/*', [FilesController, 'serve'])
-router.get('/users/:id/*', [FilesController, 'userFiles'])
-
-// Generated OpenAPI paths
-// /files{wildcard}
-// /users/{id}/{wildcard}
-```
-
-### Mixed Parameter Types
-```typescript
-// Complex routes with mixed parameter types
-router.get('/api/:version?/organizations/:orgId?/projects/:projectId/*', [ProjectsController, 'files'])
-
-// Generated OpenAPI path
-// /api/{version}/organizations/{orgId}/projects/{projectId}/{wildcard}
-```
-
-## AdonisJS Routing Rules
-
-This package follows the official AdonisJS routing conventions:
-
-- **Route patterns don't contain search parameters** - they're handled separately by the request object
-- **Wildcard parameters (*) can only appear at the end** of the path and capture all remaining segments
-- **Optional parameters use ? suffix** and can appear anywhere in the path
-- **Regular parameters use : prefix** and capture single path segments
-- **Trailing slashes are not part of route patterns** - they're handled by the router itself
+[Installation & Getting Started](https://friendsofadonis.github.io/docs/openapi/getting-started)
 
 ## License
 

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -90,7 +90,8 @@
     "luxon": "^3.5.0"
   },
   "dependencies": {
-    "openapi-metadata": "^0.2.0"
+    "openapi-metadata": "^0.2.2",
+    "yaml": "^2.8.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/openapi/src/controllers/openapi_controller.ts
+++ b/packages/openapi/src/controllers/openapi_controller.ts
@@ -1,17 +1,34 @@
 import { HttpContext } from '@adonisjs/core/http'
 import app from '@adonisjs/core/services/app'
+import router from '@adonisjs/core/services/router'
+import YAML from 'yaml'
 
 export default class OpenAPIController {
-  async handle({ request }: HttpContext) {
+  async html({ response }: HttpContext) {
     const openapi = await app.container.make('openapi')
 
-    const content = request.accepts(['json', 'html'])
+    const url = router.makeUrl('openapi.json')
 
-    if (content === 'html') {
-      return openapi.generateUi(request.url())
-    }
+    const content = openapi.generateUi(url)
 
+    return response.status(200).header('Content-Type', 'text/html').send(content)
+  }
+
+  async yaml({ response }: HttpContext) {
+    const openapi = await app.container.make('openapi')
     const document = await openapi.buildDocument()
-    return document
+
+    const body = YAML.stringify(document)
+
+    return response.status(200).header('Content-Type', 'application/yaml').send(body)
+  }
+
+  async json({ response }: HttpContext) {
+    const openapi = await app.container.make('openapi')
+    const document = await openapi.buildDocument()
+
+    const body = JSON.stringify(document)
+
+    return response.status(200).header('Content-Type', 'application/json').send(body)
   }
 }

--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -2,7 +2,7 @@ import { Logger } from '@adonisjs/core/logger'
 import { HttpRouterService } from '@adonisjs/core/types'
 import { RouteJSON } from '@adonisjs/core/types/http'
 import { OperationMetadataStorage } from 'openapi-metadata/metadata'
-import { isConstructor } from './utils.js'
+import { isConstructor, toOpenAPIPath } from './utils.js'
 import stringHelpers from '@adonisjs/core/helpers/string'
 
 export class RouterLoader {
@@ -45,10 +45,13 @@ export class RouterLoader {
 
     const name = stringHelpers.create(target.name).removeSuffix('Controller').toString()
 
+    // Transform Adonis-style path parameters to OpenAPI-compliant format
+    const openAPIPath = toOpenAPIPath(route.pattern)
+
     OperationMetadataStorage.defineMetadata(
       target.prototype,
       {
-        path: route.pattern,
+        path: openAPIPath,
         methods: route.methods.filter((m) => m !== 'HEAD').map((r) => r.toLowerCase()) as any,
         tags: [name],
       },

--- a/packages/openapi/src/utils.ts
+++ b/packages/openapi/src/utils.ts
@@ -1,3 +1,35 @@
+/**
+ * Converts Adonis-style path parameters to OpenAPI-compliant format
+ * 
+ * Handles:
+ * - Regular parameters: /users/:id → /users/{id}
+ * - Optional parameters: /users/:id? → /users{id}
+ * - Wildcard parameters: /users/* → /users/{wildcard} (only at end)
+ * - Mixed patterns: /users/:id/posts/:postId? → /users/{id}/posts/{postId}
+ * 
+ * Based on AdonisJS routing documentation:
+ * - Route patterns don't contain search params
+ * - Wildcard parameters (*) can only appear at the end of the path
+ * - Optional parameters use ? suffix
+ * - Trailing slashes are not part of route patterns
+ * 
+ * Examples:
+ * - /users/:id → /users/{id}
+ * - /posts/:postId/comments/:commentId → /posts/{postId}/comments/{commentId}
+ * - /api/v1/users/:userId? → /api/v1/users/{userId}
+ * - /files/* → /files/{wildcard}
+ * - /users/:id/posts/:postId? → /users/{id}/posts/{postId}
+ */
+export function toOpenAPIPath(path: string): string {
+  return path
+    // Handle optional parameters (remove ? after parameter)
+    .replace(/:([a-zA-Z0-9_]+)\?/g, '{$1}')
+    // Handle wildcard parameters (only at end of path)
+    .replace(/\*$/, '{wildcard}')
+    // Handle regular parameters
+    .replace(/:([a-zA-Z0-9_]+)/g, '{$1}')
+}
+
 export function isConstructor(fn: Function) {
   try {
     Reflect.construct(String, [], fn)

--- a/packages/openapi/src/utils.ts
+++ b/packages/openapi/src/utils.ts
@@ -1,33 +1,20 @@
 /**
- * Converts Adonis-style path parameters to OpenAPI-compliant format
- * 
- * Handles:
- * - Regular parameters: /users/:id → /users/{id}
- * - Optional parameters: /users/:id? → /users{id}
- * - Wildcard parameters: /users/* → /users/{wildcard} (only at end)
- * - Mixed patterns: /users/:id/posts/:postId? → /users/{id}/posts/{postId}
- * 
- * Based on AdonisJS routing documentation:
- * - Route patterns don't contain search params
- * - Wildcard parameters (*) can only appear at the end of the path
- * - Optional parameters use ? suffix
- * - Trailing slashes are not part of route patterns
- * 
- * Examples:
- * - /users/:id → /users/{id}
- * - /posts/:postId/comments/:commentId → /posts/{postId}/comments/{commentId}
- * - /api/v1/users/:userId? → /api/v1/users/{userId}
- * - /files/* → /files/{wildcard}
- * - /users/:id/posts/:postId? → /users/{id}/posts/{postId}
+ * Converts Adonis-style path to OpenAPI-compliant format
+ *
+ * @param path - Adonis-style path (eg. /users/:id)
+ *
+ * @returns OpenAPI-compliant path (eg. /users/{id})
  */
 export function toOpenAPIPath(path: string): string {
-  return path
-    // Handle optional parameters (remove ? after parameter)
-    .replace(/:([a-zA-Z0-9_]+)\?/g, '{$1}')
-    // Handle wildcard parameters (only at end of path)
-    .replace(/\*$/, '{wildcard}')
-    // Handle regular parameters
-    .replace(/:([a-zA-Z0-9_]+)/g, '{$1}')
+  return (
+    path
+      // Handle optional parameters (remove ? after parameter)
+      .replace(/:([a-zA-Z0-9_]+)\?/g, '{$1}')
+      // Handle wildcard parameters (only at end of path)
+      .replace(/\*$/, '{wildcard}')
+      // Handle regular parameters
+      .replace(/:([a-zA-Z0-9_]+)/g, '{$1}')
+  )
 }
 
 export function isConstructor(fn: Function) {

--- a/packages/openapi/tests/utils.spec.ts
+++ b/packages/openapi/tests/utils.spec.ts
@@ -1,0 +1,149 @@
+import { test } from '@japa/runner'
+import { toOpenAPIPath } from '../src/utils.js'
+
+test.group('Utils - toOpenAPIPath', () => {
+  test('should convert simple path parameter', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:id'), '/users/{id}')
+  })
+
+  test('should convert multiple path parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/posts/:postId/comments/:commentId'), '/posts/{postId}/comments/{commentId}')
+  })
+
+  test('should convert path parameters with underscores', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/api/users/:user_id'), '/api/users/{user_id}')
+  })
+
+  test('should convert path parameters with numbers', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/api/v1/users/:user123'), '/api/v1/users/{user123}')
+  })
+
+  test('should handle paths with no parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users'), '/users')
+    assert.equal(toOpenAPIPath('/api/health'), '/api/health')
+    assert.equal(toOpenAPIPath('/'), '/')
+  })
+
+  test('should handle paths with mixed content', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/api/v1/users/:userId/posts/:postId/comments'), '/api/v1/users/{userId}/posts/{postId}/comments')
+  })
+
+  test('should handle complex nested paths with multiple parameters', ({ assert }) => {
+    assert.equal(
+      toOpenAPIPath('/api/v1/organizations/:orgId/projects/:projectId/tasks/:taskId'),
+      '/api/v1/organizations/{orgId}/projects/{projectId}/tasks/{taskId}'
+    )
+  })
+
+  test('should handle paths with multiple consecutive parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/:type/:id/:action'), '/{type}/{id}/{action}')
+  })
+
+  test('should handle paths with parameters at the beginning', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/:locale/users'), '/{locale}/users')
+  })
+
+  test('should handle paths with parameters at the end', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:id'), '/users/{id}')
+  })
+
+  test('should handle edge cases with special characters', ({ assert }) => {
+    // Should only match valid parameter names (alphanumeric + underscore)
+    assert.equal(toOpenAPIPath('/users/:id-123'), '/users/{id}-123')
+    assert.equal(toOpenAPIPath('/users/:id.123'), '/users/{id}.123')
+    assert.equal(toOpenAPIPath('/users/:id/123'), '/users/{id}/123')
+  })
+
+  test('should handle empty string', ({ assert }) => {
+    assert.equal(toOpenAPIPath(''), '')
+  })
+
+  test('should handle paths with only parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/:id'), '/{id}')
+    assert.equal(toOpenAPIPath('/:id/:name'), '/{id}/{name}')
+  })
+
+  test('should handle paths with multiple slashes', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/api//v1//users/:id'), '/api//v1//users/{id}')
+  })
+
+  test('should handle paths with mixed case parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:userId/posts/:PostId'), '/users/{userId}/posts/{PostId}')
+  })
+
+  // Tests for optional parameters
+  test('should handle optional parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:id?'), '/users/{id}')
+    assert.equal(toOpenAPIPath('/posts/:postId?/comments'), '/posts/{postId}/comments')
+    assert.equal(toOpenAPIPath('/api/:version?/users/:id'), '/api/{version}/users/{id}')
+  })
+
+  test('should handle multiple optional parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:id?/posts/:postId?'), '/users/{id}/posts/{postId}')
+    assert.equal(toOpenAPIPath('/:locale?/users/:id?/posts'), '/{locale}/users/{id}/posts')
+  })
+
+  test('should handle optional parameters in complex paths', ({ assert }) => {
+    assert.equal(
+      toOpenAPIPath('/api/:version?/organizations/:orgId?/projects/:projectId'),
+      '/api/{version}/organizations/{orgId}/projects/{projectId}'
+    )
+  })
+
+  // Tests for wildcard parameters (only at end)
+  test('should handle wildcard parameters at end', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/files/*'), '/files/{wildcard}')
+    assert.equal(toOpenAPIPath('/static/*'), '/static/{wildcard}')
+    assert.equal(toOpenAPIPath('/*'), '/{wildcard}')
+  })
+
+  test('should handle wildcard parameters with other parameters', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/users/:id/*'), '/users/{id}/{wildcard}')
+    assert.equal(toOpenAPIPath('/api/:version/*'), '/api/{version}/{wildcard}')
+    assert.equal(toOpenAPIPath('/:locale/*'), '/{locale}/{wildcard}')
+  })
+
+  test('should NOT handle wildcard parameters in middle of path', ({ assert }) => {
+    // Wildcards in the middle should not be transformed (invalid AdonisJS pattern)
+    assert.equal(toOpenAPIPath('/files/*/versions'), '/files/*/versions')
+    assert.equal(toOpenAPIPath('/users/*/posts'), '/users/*/posts')
+  })
+
+  // Tests for mixed parameter types
+  test('should handle mixed parameter types', ({ assert }) => {
+    assert.equal(
+      toOpenAPIPath('/api/:version?/users/:id/*'),
+      '/api/{version}/users/{id}/{wildcard}'
+    )
+    assert.equal(
+      toOpenAPIPath('/:locale?/posts/:postId?/*'),
+      '/{locale}/posts/{postId}/{wildcard}'
+    )
+  })
+
+  test('should handle complex mixed patterns', ({ assert }) => {
+    assert.equal(
+      toOpenAPIPath('/api/:version?/organizations/:orgId?/projects/:projectId/*'),
+      '/api/{version}/organizations/{orgId}/projects/{projectId}/{wildcard}'
+    )
+  })
+
+  // Edge cases for new parameter types
+  test('should handle edge cases for optional parameters', ({ assert }) => {
+    // Optional parameter at end of path
+    assert.equal(toOpenAPIPath('/users/:id?'), '/users/{id}')
+    
+    // Optional parameter before another segment
+    assert.equal(toOpenAPIPath('/users/:id?/posts'), '/users/{id}/posts')
+  })
+
+  test('should handle edge cases for wildcard parameters', ({ assert }) => {
+    // Wildcard at end of path
+    assert.equal(toOpenAPIPath('/files/*'), '/files/{wildcard}')
+  })
+
+  test('should handle empty segments with new parameter types', ({ assert }) => {
+    assert.equal(toOpenAPIPath('/:id?/:name?'), '/{id}/{name}')
+    assert.equal(toOpenAPIPath('/:id/*'), '/{id}/{wildcard}')
+  })
+}) 

--- a/playgrounds/openapi/adonisrc.ts
+++ b/playgrounds/openapi/adonisrc.ts
@@ -14,7 +14,6 @@ export default defineConfig({
     () => import('@adonisjs/core/commands'),
     () => import('@adonisjs/lucid/commands'),
     () => import('@adonisjs/bouncer/commands'),
-    () => import('@foadonis/crypt/commands')
   ],
 
   /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,12 +2419,13 @@ __metadata:
     copyfiles: "npm:^2.4.1"
     del-cli: "npm:^6.0.0"
     luxon: "npm:^3.6.1"
-    openapi-metadata: "npm:^0.2.0"
+    openapi-metadata: "npm:^0.2.2"
     openapi-types: "npm:^12.1.3"
     prettier: "npm:^3.5.3"
     reflect-metadata: "npm:^0.2.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.8.3"
+    yaml: "npm:^2.8.1"
   peerDependencies:
     "@adonisjs/core": ^6.2.0
     "@adonisjs/lucid": ^21.2.0
@@ -16216,16 +16217,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openapi-metadata@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "openapi-metadata@npm:0.2.0"
+"openapi-metadata@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "openapi-metadata@npm:0.2.2"
   dependencies:
     deepmerge: "npm:^4.3.1"
     openapi-types: "npm:^12.1.3"
-    type-fest: "npm:^4.31.0"
+    type-fest: "npm:^4.40.1"
   peerDependencies:
     reflect-metadata: ^0.2.2
-  checksum: 10c0/6f9fd90f52852c618d90bc73569c8387e63d7b363f8ced240b84e8042be22cdea380d1deda6f2f175c3e8e3ddd880fe32b813b0d60153dcbbd4bf0b8da7c8f98
+  checksum: 10c0/869064ff3085966118c72b5748a54af62b347facc2a8fa84cd3668c8b57218b5f5e2056549cabdb3735ea8b22d89f79f7e069736cd6fcb2313a069be1b1f8ff7
   languageName: node
   linkType: hard
 
@@ -20130,6 +20131,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^4.40.1":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^4.6.0, type-fest@npm:^4.7.1":
   version: 4.32.0
   resolution: "type-fest@npm:4.32.0"
@@ -21126,6 +21134,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/886a7d2abbd70704b79f1d2d05fe9fb0aa63aefb86e1cb9991837dced65193d300f5554747a872b4b10ae9a12bc5d5327e4d04205f70336e863e35e89d8f4ea9
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "yaml@npm:2.8.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 Description

- Fixes #73

## 🔄 What's new

<!-- Please list changes done by this pull-request. -->

- ✨ Automatically convert AdonisJS paths to OpenAPI compliant paths
- 💥 Remove content-negotiation in favor of routes extensions

## 📦 Package(s) Affected

<!-- Please delete options that are not relevant. -->

- [x] @foadonis/openapi
- [x] Documentation

## 🔍 What Does This PR Do?

### Convert AdonisJS paths to OpenAPI compliant paths

Paths are now automatically converted to OpenAPI compliant paths when loaded using the new util `toOpenAPIPath`

### Routes extensions

As content negotiation was causing issues when some default middlewares were configured (enforcing json). To improve DX it now uses extensions:
- /api
- /api.json
- /api.yaml

## 🔄 Breaking Changes

<!-- If this PR introduces breaking changes, please describe them and provide migration instructions. -->

- [x] This PR introduces breaking changes
- [ ] This PR does not introduce breaking changes

## 📋 Requirements

<!-- Please only check the elements that applies. -->

- [ ] I have read and follow the [contributing guidelines](https://github.com/FriendsOfAdonis/FriendsOfAdonis/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added changesets that reflects my changes
- [ ] I have added automated tests

## ✨ AI Usage

<!-- We do not have an anti-AI policy but are more careful on the reviews when AI has been used -->

- [ ] I have used generative AI to write the pull-request