### PR TITLE
test(magnify): upgrade typesense to v29.0

### DIFF
--- a/packages/magnify/tests/helpers.ts
+++ b/packages/magnify/tests/helpers.ts
@@ -21,7 +21,7 @@ export const CONTAINERS = {
       retries: 5,
       startPeriod: 1000,
     }),
-  typesense: new GenericContainer('typesense/typesense:27.0')
+  typesense: new GenericContainer('typesense/typesense:29.0')
     .withCommand(['--api-key=superrandomkey', '--data-dir=/tmp'])
     .withExposedPorts(8108)
     .withHealthCheck({
@@ -154,7 +154,7 @@ async function seedDatabase() {
 
   // To ensure proper order we manually set createdAt
   const toCreate = [
-    ...collection().map((v) => {
+    ...Array.from(collection()).map((v) => {
       date = date.minus({ seconds: 1 })
       return {
         ...v,
@@ -162,6 +162,7 @@ async function seedDatabase() {
       }
     }),
   ]
+
   await User.createMany(toCreate)
 }
 


### PR DESCRIPTION
## 🔄 What's new

<!-- Please list changes done by this pull-request. -->

- ✅ Test additions or updates
- Perform test using typesense 29 (latest version)

## 📦 Package(s) Affected

<!-- Please delete options that are not relevant. -->

- [x] @foadonis/magnify

## 🔍 What Does This PR Do?

Bump the testcontainer `typesense/typesense:27.0` to `typesense/typesense:29.0`

## 🔄 Breaking Changes

<!-- If this PR introduces breaking changes, please describe them and provide migration instructions. -->

- [ ] This PR introduces breaking changes
- [x] This PR does not introduce breaking changes

## 📋 Requirements

<!-- Please only check the elements that applies. -->

- [x] I have read and follow the [contributing guidelines](https://github.com/FriendsOfAdonis/FriendsOfAdonis/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added changesets that reflects my changes
- [x] I have added automated tests

## ✨ AI Usage

<!-- We do not have an anti-AI policy but are more careful on the reviews when AI has been used -->

- [ ] I have used generative AI to write the pull-request
