### PR TITLE
fix(openapi): preserve stubs directory when copying templates

### DIFF
--- a/.changeset/fresh-mammals-wink.md
+++ b/.changeset/fresh-mammals-wink.md
@@ -1,0 +1,10 @@
+---
+'@foadonis/maintenance': patch
+'@foadonis/autoloader': patch
+'@foadonis/actions': patch
+'@foadonis/graphql': patch
+'@foadonis/magnify': patch
+'@foadonis/openapi': patch
+---
+
+Fix stub templates being copied to the wrong directory during build.

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/autoloader/package.json
+++ b/packages/autoloader/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/magnify/package.json
+++ b/packages/magnify/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/shopkeeper/package.json
+++ b/packages/shopkeeper/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "clean": "del-cli build",
-    "copy:templates": "cpy \"stubs/**/*.stub\" build",
+    "copy:templates": "cpy \"stubs/**/*.stub\" build/stubs",
     "copy:resources": "cpy \"resources/**/*.edge\" build",
     "index:commands": "adonis-kit index build/commands",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 📝 Description

Fixes the configuration error when installing `@foadonis/openapi`.

When running:

    node ace add @foadonis/openapi

or:

    node ace configure @foadonis/openapi

Adonis throws:

    RuntimeException: Unable to find stub "config/openapi.stub"

The stub existed but was copied to the wrong directory during the build step.

Fixes #110

## 🔄 What's new

-   🐛 Bug fix (non-breaking change which fixes an issue)

## 📦 Package(s) Affected

- [x] @foadonis/maintenance
- [x] @foadonis/autoloader
- [x] @foadonis/actions
- [x] @foadonis/graphql
- [x] @foadonis/magnify
- [x] @foadonis/openapi

## 🔍 What Does This PR Do?

The build step previously copied stub templates using:

    cpy "stubs/**/*.stub" build

This flattened the directory structure and produced:

    build/config/openapi.stub

However Adonis resolves stubs relative to `build/stubs`, so it expects:

    build/stubs/config/openapi.stub

This PR updates the copy step to preserve the correct structure by copying templates into `build/stubs`.

## 🧪 Testing

Tested locally by:

1.  Building the package
2.  Installing it in a fresh AdonisJS v7 project
3.  Running:

        node ace configure @foadonis/openapi

Before this change the command failed with:

    RuntimeException: Unable to find stub "config/openapi.stub"

After the fix the command completes successfully and generates:

    config/openapi.ts

## 💡 Additional Notes

This issue happens because Adonis resolves stubs relative to `build/stubs` when running `codemods.makeUsingStub`.
Preserving the original `stubs` directory structure fixes the lookup.

## 🔄 Breaking Changes

-   [ ] This PR introduces breaking changes
-   [x] This PR does not introduce breaking changes

## 📋 Requirements

-   [x] I have read and follow the contributing guidelines
-   [x] I have performed a self-review of my own code
-   [ ] I have updated the documentation accordingly (if applicable)
-   [ ] I have added changesets that reflects my changes
-   [ ] I have added automated tests

## ✨ AI Usage

-   [x] I have used generative AI to write the pull-request
