### PR TITLE
Fix typo in yoga stub

### DIFF
--- a/.changeset/hip-symbols-sin.md
+++ b/.changeset/hip-symbols-sin.md
@@ -1,0 +1,5 @@
+---
+'@foadonis/graphql': patch
+---
+
+Fix typo in yoga stub

--- a/packages/graphql/stubs/config/yoga.stub
+++ b/packages/graphql/stubs/config/yoga.stub
@@ -19,7 +19,7 @@ const graphqlConfig = defineConfig({
   driver: drivers.yoga({
     graphiql: isDevelopment,
     plugins: isDevelopment ? [] : [useDisableIntrospection()]
-  })
+  }),
 
   /**
    * Logger name used by the GraphQL server.


### PR DESCRIPTION
## 📝 Description

- Fixes # (issue)

Fix typo in yoga stub.

## 🔄 What's new

- 🐛 Bug fix (non-breaking change which fixes an issue)

## 📦 Package(s) Affected

- [ ] @foadonis/actions
- [ ] @foadonis/crypt
- [x] @foadonis/graphql
- [ ] @foadonis/lucid-parser
- [ ] @foadonis/magnify
- [ ] @foadonis/maintenance
- [ ] @foadonis/openapi
- [ ] @foadonis/shopkeeper
- [ ] Tooling/Infrastructure
- [ ] Documentation

## 🔍 What Does This PR Do?

Fixes a typo in the yoga stub. Missing `,` character.

## 🧪 Testing

No specific tests required. Verified the fix manually.

## 💡 Additional Notes

Includes a changeset with a patch version bump.

## 🔄 Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does not introduce breaking changes

## 📋 Requirements

- [x] I have read and follow the contributing guidelines
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added changesets that reflects my changes
- [ ] I have added automated tests

## ✨ AI Usage

- [ ] I have used generative AI to write the pull-request