### PR TITLE
fix(openapi): guard against undefined tokens in RouterLoader

### DIFF
--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -54,7 +54,7 @@ export class RouterLoader {
 
     // Transform Adonis-style path parameters to OpenAPI-compliant format
     const openAPIPath = toOpenAPIPath(route.pattern)
-    const params = route.tokens.filter((item) => item.type === 1).map((item) => item.val)
+    const params = (route.tokens ?? []).filter((item) => item.type === 1).map((item) => item.val)
 
     const existing = OperationMetadataStorage.getMetadata(target.prototype, propertyKey, true)
 


### PR DESCRIPTION
## 📝 Description
Fixes: calling `RouterLoader.loadRouteController()` when the route was
registered under `@adonisjs/core` ^6.2.0 (http-server ^7.x).

## 🔄 What's new
- 🐛 Bug fix (non-breaking change which fixes an issue)

## 📦 Package(s) Affected
- [X] @foadonis/openapi

## 🔍 What Does This PR Do?

`@adonisjs/http-server` v7 (shipped with `@adonisjs/core` v6) does not
include a `tokens` field in its serialized `RouteJSON` — that field was
only introduced in `@adonisjs/http-server` v8. Because the loader called
`.filter()` directly on `route.tokens`, every app running AdonisJS v6
would crash at OpenAPI load time with a TypeError on undefined.

## 🧪 Testing

<!-- Please describe how ce can test your changes -->

## 💡 Additional Notes

<!-- Add any other context about the pull request here. -->

## 🔄 Breaking Changes

<!-- If this PR introduces breaking changes, please describe them and provide migration instructions. -->

- [X] This PR does not introduce breaking changes

## 📋 Requirements

<!-- Please only check the elements that applies. -->

- [X] I have read and follow the [contributing guidelines](https://github.com/FriendsOfAdonis/FriendsOfAdonis/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added changesets that reflects my changes
- [ ] I have added automated tests

## ✨ AI Usage

- [X] I have used generative AI to write the pull-request
