### PR TITLE
fix(shopkeeper): install not working

### DIFF
--- a/.changeset/moody-dingos-show.md
+++ b/.changeset/moody-dingos-show.md
@@ -1,0 +1,5 @@
+---
+"@foadonis/shopkeeper": minor
+---
+
+Fixed package install and docs version mismatch

--- a/packages/shopkeeper/CHANGELOG.md
+++ b/packages/shopkeeper/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major Changes
 
-- [#116](https://github.com/FriendsOfAdonis/FriendsOfAdonis/pull/116) [`3d1e30d`](https://github.com/FriendsOfAdonis/FriendsOfAdonis/commit/3d1e30d9b326bf6e051f453e7eb73a1e355d1450) Thanks [@densetsuuu](https://github.com/densetsuuu)! - Shopkeeper 0.2.0 — full rewrite with breaking changes across the public API.
+- [#116](https://github.com/FriendsOfAdonis/FriendsOfAdonis/pull/116) [`3d1e30d`](https://github.com/FriendsOfAdonis/FriendsOfAdonis/commit/3d1e30d9b326bf6e051f453e7eb73a1e355d1450) Thanks [@densetsuuu](https://github.com/densetsuuu)! - Shopkeeper 1.0.0 — full rewrite with breaking changes across the public API.
 
   See the [migration guide](https://friendsofadonis.com/docs/shopkeeper/migration) for step-by-step upgrade instructions.
 

--- a/packages/shopkeeper/UPGRADE.md
+++ b/packages/shopkeeper/UPGRADE.md
@@ -1,4 +1,4 @@
-# Upgrading to @foadonis/shopkeeper 0.2.0
+# Upgrading to @foadonis/shopkeeper 1.0.0
 
 See the full migration guide at:
 

--- a/packages/shopkeeper/package.json
+++ b/packages/shopkeeper/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "build",
+    "build/stubs",
     "!build/bin",
     "!build/tests"
   ],


### PR DESCRIPTION
## 📝 Description
As reported in #131 , `node ace add @foadonis/shopkeeper`is failing because stubs are not exported in `files` of the package.json
Also fixed the version mismatch between the docs and the actual package.

- Fixes #131

## 🔄 What's new

<!-- Please list changes done by this pull-request. -->

- 🐛 Bug fix (non-breaking change which fixes an issue)

## 📦 Package(s) Affected

- [x] @foadonis/shopkeeper
- [x] Documentation
