### PR TITLE
fix(openapi): mark auto-discovered path parameters as required

### DIFF
--- a/.changeset/openapi-path-params-required.md
+++ b/.changeset/openapi-path-params-required.md
@@ -2,4 +2,4 @@
 "@foadonis/openapi": patch
 ---
 
-Mark auto-discovered path parameters as `required` in the generated OpenAPI document. Path parameters are always required per the OpenAPI Specification, and omitting the flag produced a technically-invalid document that strict generators such as `openapi-python-client` reject — silently skipping every operation that has a path parameter.
+Mark auto-discovered path parameters as `required` in the generated OpenAPI document.

--- a/.changeset/openapi-path-params-required.md
+++ b/.changeset/openapi-path-params-required.md
@@ -1,0 +1,5 @@
+---
+"@foadonis/openapi": patch
+---
+
+Mark auto-discovered path parameters as `required` in the generated OpenAPI document. Path parameters are always required per the OpenAPI Specification, and omitting the flag produced a technically-invalid document that strict generators such as `openapi-python-client` reject — silently skipping every operation that has a path parameter.

--- a/.changeset/openapi-path-params-required.md
+++ b/.changeset/openapi-path-params-required.md
@@ -1,5 +1,5 @@
 ---
-"@foadonis/openapi": patch
+"@foadonis/openapi": minor
 ---
 
 Mark auto-discovered path parameters as `required` in the generated OpenAPI document.

--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -72,7 +72,11 @@ export class RouterLoader {
     for (const param of params) {
       OperationParameterMetadataStorage.mergeMetadata(
         target.prototype,
-        [{ in: 'path', type: 'string', name: param }],
+        // Path parameters are ALWAYS required per the OpenAPI Specification
+        // (https://spec.openapis.org/oas/v3.1.0#parameter-object). Omitting
+        // `required` produces an invalid document that strict tooling — e.g.
+        // `openapi-python-client` — rejects, silently dropping the operation.
+        [{ in: 'path', type: 'string', name: param, required: true }],
         propertyKey
       )
     }

--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -72,10 +72,6 @@ export class RouterLoader {
     for (const param of params) {
       OperationParameterMetadataStorage.mergeMetadata(
         target.prototype,
-        // Path parameters are ALWAYS required per the OpenAPI Specification
-        // (https://spec.openapis.org/oas/v3.1.0#parameter-object). Omitting
-        // `required` produces an invalid document that strict tooling — e.g.
-        // `openapi-python-client` — rejects, silently dropping the operation.
         [{ in: 'path', type: 'string', name: param, required: true }],
         propertyKey
       )

--- a/packages/openapi/tests/loader.spec.ts
+++ b/packages/openapi/tests/loader.spec.ts
@@ -1,0 +1,46 @@
+import { test } from '@japa/runner'
+import type { RouteJSON } from '@adonisjs/core/types/http'
+import { RouterLoader } from '../src/loader.ts'
+import { OperationParameterMetadataStorage } from '@martin.xyz/openapi-decorators/metadata'
+
+test.group('RouterLoader', () => {
+  test('marks auto-discovered path parameters as required', async ({ assert }) => {
+    class DevicesController {
+      show() {}
+    }
+
+    // Minimal route for `GET /api/devices/:id` — only the fields the loader reads.
+    const route = {
+      pattern: '/api/devices/:id',
+      methods: ['GET', 'HEAD'],
+      handler: { reference: [DevicesController, 'show'] },
+      tokens: [
+        { type: 0, val: 'api' },
+        { type: 0, val: 'devices' },
+        { type: 1, val: 'id' },
+      ],
+    } as unknown as RouteJSON
+
+    const loader = new RouterLoader(
+      {} as unknown as ConstructorParameters<typeof RouterLoader>[0],
+      console as unknown as ConstructorParameters<typeof RouterLoader>[1],
+      () => []
+    )
+
+    await loader.loadRouteController(route)
+
+    const parameters = OperationParameterMetadataStorage.getMetadata(
+      DevicesController.prototype,
+      'show'
+    )
+
+    // Path parameters are always required per the OpenAPI Specification.
+    assert.lengthOf(parameters, 1)
+    assert.deepEqual(parameters[0], {
+      in: 'path',
+      type: 'string',
+      name: 'id',
+      required: true,
+    })
+  })
+})


### PR DESCRIPTION
## 📝 Description

Path parameters discovered by `RouterLoader` are emitted without `required`, producing a technically-invalid OpenAPI document. Strict generators (e.g. `openapi-python-client`) then silently drop every operation that has a path parameter.

- Fixes #140

## 🔄 What's new

- 🐛 Bug fix (non-breaking change which fixes an issue)
- ✅ Test additions or updates

## 📦 Package(s) Affected

- [x] @foadonis/openapi

## 🔍 What Does This PR Do?

The [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0#parameter-object) mandates that every path parameter be `required: true`. `RouterLoader.loadRouteController()` discovers path params from the route pattern and injects them as:

```ts
[{ in: 'path', type: 'string', name: param }]
```

— i.e. without `required`. This PR adds `required: true` to that injection. A path parameter is required by definition, so this is unconditionally correct.

## 🧪 Testing

Adds `packages/openapi/tests/loader.spec.ts`, which drives `RouterLoader.loadRouteController()` for a `GET /api/devices/:id` route and asserts the discovered path parameter is marked `required: true`.

Locally green for `@foadonis/openapi`:

- `yarn typecheck` ✅
- `yarn quick:test` ✅ (34 passed)
- `oxlint` ✅ (0 warnings, 0 errors)
- `oxfmt --check` ✅

## 💡 Additional Notes

Related to #124 (`ApiSchema` dropping `required` on params/qs/headers/cookies) but a **distinct code path**: #124 is in `iterateSchemaProperties()` / `generateOperation`, whereas this is the route-token auto-discovery in `RouterLoader`. This PR does not address #124.

## 🔄 Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does not introduce breaking changes

## 📋 Requirements

- [x] I have read and follow the [contributing guidelines](https://github.com/FriendsOfAdonis/FriendsOfAdonis/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added changesets that reflects my changes
- [x] I have added automated tests

## ✨ AI Usage

- [x] I have used generative AI to write the pull-request
