### PR TITLE
feat(graphql): support Bouncer policies and Yoga file uploads

### DIFF
--- a/.changeset/graphql-bouncer-policies.md
+++ b/.changeset/graphql-bouncer-policies.md
@@ -1,0 +1,5 @@
+---
+"@foadonis/graphql": minor
+---
+
+`@Authorized` now accepts Bouncer policies (`@Authorized(RecipePolicy, 'edit')`) and passes the parent object to abilities and policy methods when protecting fields. Authorization is fully delegated to Bouncer, so `allowGuest` abilities and policy methods are now evaluated for unauthenticated users.

--- a/.changeset/graphql-yoga-file-uploads.md
+++ b/.changeset/graphql-yoga-file-uploads.md
@@ -1,0 +1,5 @@
+---
+"@foadonis/graphql": patch
+---
+
+The Yoga driver now streams multipart requests to GraphQL Yoga, enabling file uploads through the GraphQL multipart request specification. Previously `request.raw()` returned `null` for multipart bodies (which the bodyparser never buffers), so uploads always failed. Add your GraphQL endpoint to the bodyparser `processManually` list to use file uploads.

--- a/docs/content/docs/graphql/(concepts)/authorization.mdx
+++ b/docs/content/docs/graphql/(concepts)/authorization.mdx
@@ -61,7 +61,7 @@ class RecipeResolver {
 import { Bouncer } from '@adonisjs/bouncer'
 
 const abilities = {
-  isAdmin = Bouncer.ability((user) => user.isAdmin),
+  isAdmin: Bouncer.ability((user) => user.isAdmin),
 }
 
 export default abilities
@@ -74,6 +74,51 @@ export default abilities
   pass.
 </Callout>
 
+<Callout>
+  The `@Authorized` decorator can also be applied on a resolver class to protect all of its
+  operations. When an operation defines its own `@Authorized`, its rules replace the class-level
+  ones, they are not merged.
+</Callout>
+
+## Using Policies
+
+The `Authorized` decorator also accepts a [Bouncer policy](https://docs.adonisjs.com/guides/security/authorization#defining-policies) with the name of the method to use for authorization.
+
+<Tabs items={["app/graphql/resolvers/recipe_resolver.ts", "app/policies/recipe_policy.ts"]}>
+
+```ts tab="app/graphql/resolvers/recipe_resolver.ts" twoslash
+// @noErrors
+import Recipe from '#models/recipe'
+import RecipePolicy from '#policies/recipe_policy'
+import { Resolver, Query, Authorized } from '@foadonis/graphql'
+
+@Resolver(Recipe)
+class RecipeResolver {
+  @Query(() => [Recipe])
+  @Authorized(RecipePolicy, 'viewList') // [!code highlight]
+  recipes() {
+    // ...your logic
+  }
+}
+```
+
+```ts tab="app/policies/recipe_policy.ts" twoslash
+// @noErrors
+import User from '#models/user'
+import { BasePolicy } from '@adonisjs/bouncer'
+import { AuthorizerResponse } from '@adonisjs/bouncer/types'
+
+export default class RecipePolicy extends BasePolicy {
+  viewList(user: User): AuthorizerResponse {
+    return user.isAdmin
+  }
+}
+```
+
+</Tabs>
+
+Policies are resolved through the [IoC container](https://docs.adonisjs.com/concepts/dependency-injection), so you can inject dependencies in them like anywhere else in your Adonis application.
+
 ## Secure objects
 
 The `@Authorized` decorator also works on fields allowing you to protect only certain fields.
@@ -81,7 +126,7 @@ With the following example, only authenticated user can access the `fullName` an
 
 ```ts title="app/models/user.ts" twoslash
 // @noErrors
-import { ObjectType, Authorized } from '@foadonis/graphql'
+import { ObjectType, Field, Authorized } from '@foadonis/graphql'
 import abilities from '#abilities/main'
 
 @ObjectType()
@@ -98,6 +143,69 @@ export default class User {
   declare email: string
 }
 ```
+
+### Accessing the object
+
+When `@Authorized` protects a field (or a field resolver), the parent object is passed to the ability or policy method after the user. This allows authorization rules based on the object itself, like restricting a field to its owner:
+
+<Tabs items={["app/models/recipe.ts", "app/policies/recipe_policy.ts"]}>
+
+```ts tab="app/models/recipe.ts" twoslash
+// @noErrors
+import { ObjectType, Field, Authorized } from '@foadonis/graphql'
+import RecipePolicy from '#policies/recipe_policy'
+
+@ObjectType()
+export default class Recipe {
+  @Field()
+  declare title: string
+
+  @Field()
+  @Authorized(RecipePolicy, 'viewSecret') // [!code highlight]
+  declare secretIngredient: string
+}
+```
+
+```ts tab="app/policies/recipe_policy.ts" twoslash
+// @noErrors
+import User from '#models/user'
+import Recipe from '#models/recipe'
+import { BasePolicy } from '@adonisjs/bouncer'
+import { AuthorizerResponse } from '@adonisjs/bouncer/types'
+
+export default class RecipePolicy extends BasePolicy {
+  viewSecret(user: User, recipe: Recipe): AuthorizerResponse {
+    return recipe.authorId === user.id
+  }
+}
+```
+
+</Tabs>
+
+<Callout type="warn">
+  On queries and mutations there is no parent object: the ability or policy method receives
+  `undefined` instead. To authorize against an object that is not resolved yet, fetch it inside the
+  resolver and use [`ctx.bouncer`](https://docs.adonisjs.com/guides/security/authorization) directly.
+</Callout>
+
+## Allowing guests
+
+A bare `@Authorized()` always requires an authenticated user. When abilities or policies are provided, the decision is delegated to Bouncer: [abilities and policy methods that allow guests](https://docs.adonisjs.com/guides/security/authorization#allowing-guest-users) are evaluated even when no user is logged in.
+
+```ts title="app/abilities/main.ts" twoslash
+// @noErrors
+import { Bouncer } from '@adonisjs/bouncer'
+
+export const viewRecipe = Bouncer.ability({ allowGuest: true }, (user, recipe) => {
+  return recipe.isPublished || recipe.authorId === user?.id
+})
+```
+
+<Callout type="warn">
+  A policy [`before` hook](https://docs.adonisjs.com/guides/security/authorization#policy-hooks)
+  runs before the guest check. If it returns a truthy value for a `null` user, guests are
+  authorized for every method of the policy, including methods not marked with `@allowGuest()`.
+</Callout>
 
 ## Access authenticated User
 

--- a/docs/content/docs/graphql/drivers/yoga.mdx
+++ b/docs/content/docs/graphql/drivers/yoga.mdx
@@ -31,6 +31,47 @@ It is highly recommended **to disable the playground and introspection** in prod
 
 </Callout>
 
+## File Uploads
+
+GraphQL Yoga supports file uploads out of the box using the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec). For the uploads to reach Yoga, the AdonisJS bodyparser must not consume the multipart stream: add your GraphQL endpoint to the `processManually` list in your bodyparser configuration.
+
+```ts title="config/bodyparser.ts"
+import { defineConfig } from '@adonisjs/core/bodyparser'
+
+const bodyParserConfig = defineConfig({
+  multipart: {
+    autoProcess: true,
+    processManually: ['/graphql'],
+  },
+})
+
+export default bodyParserConfig
+```
+
+You can then declare a `File` scalar and use it as an argument in your mutations. The resolver receives a [WHATWG `File`](https://developer.mozilla.org/en-US/docs/Web/API/File) instance.
+
+```ts title="app/graphql/scalars/file.ts"
+import { GraphQLScalarType } from 'graphql'
+
+export const FileScalar = new GraphQLScalarType({
+  name: 'File',
+  description: 'The `File` scalar type represents a file upload.',
+})
+```
+
+```ts title="app/graphql/resolvers/document_resolver.ts"
+import { Arg, Mutation, Resolver } from '@foadonis/graphql'
+import { FileScalar } from '../scalars/file.js'
+
+@Resolver()
+export default class DocumentResolver {
+  @Mutation(() => String)
+  async uploadDocument(@Arg('file', () => FileScalar) file: File) {
+    return `Received ${file.name} (${file.size} bytes)`
+  }
+}
+```
+
 ## Plugins
 
 GraphQL Yoga supports a powerful plugin system that allows you to extend the server's functionality. You can add plugins to handle logging, error reporting, caching, and more.

--- a/packages/graphql/index.ts
+++ b/packages/graphql/index.ts
@@ -1,24 +1,16 @@
-import { type BouncerAbility } from '@adonisjs/bouncer/types'
-
 export { configure } from './configure.js'
 export { defineConfig, drivers } from './src/define_config.js'
 export * as errors from './src/errors/main.js'
 export { CurrentUser } from './src/decorators/user.js'
+export { Authorized } from './src/decorators/authorized.js'
 export { indexResolvers } from './src/hooks/index_resolvers.js'
 
 export type {
   ResolverData,
   GraphQLMiddleware,
   GraphQLConfig as GraphQlConfig,
+  AuthorizationRule,
+  PolicyAuthorizationRule,
 } from './src/types.js'
-
-type MethodPropClassDecorator = PropertyDecorator & MethodDecorator & ClassDecorator
-
-// Overwrite Authorized decorator declaration
-export declare function Authorized(): MethodPropClassDecorator
-export declare function Authorized(roles: readonly BouncerAbility<any>[]): MethodPropClassDecorator
-export declare function Authorized(
-  ...roles: readonly BouncerAbility<any>[]
-): MethodPropClassDecorator
 
 export * from 'type-graphql'

--- a/packages/graphql/src/auth_checker.ts
+++ b/packages/graphql/src/auth_checker.ts
@@ -3,36 +3,56 @@ import { type AuthChecker } from 'type-graphql'
 import { type Bouncer } from '@adonisjs/bouncer'
 import { type BouncerAbility } from '@adonisjs/bouncer/types'
 import { UnavailableFeatureError } from './errors/unavailable_feature.js'
+import { type AuthorizationRule, type PolicyAuthorizationRule } from './types.js'
 
-export const authChecker: AuthChecker<HttpContext, BouncerAbility<any>> = async (
-  { context },
-  abilities
+function isPolicyRule(rule: AuthorizationRule): rule is PolicyAuthorizationRule {
+  return typeof rule === 'object' && rule !== null && 'policy' in rule && 'method' in rule
+}
+
+function isAbility(rule: AuthorizationRule): rule is BouncerAbility<any> {
+  return typeof rule === 'object' && rule !== null && 'execute' in rule && 'original' in rule
+}
+
+export const authChecker: AuthChecker<HttpContext, AuthorizationRule> = async (
+  { root, context },
+  rules
 ) => {
-  if (!('auth' in context)) {
-    throw new UnavailableFeatureError(
-      `You tried to use Authentication features but no authenticator is available in HttpContext.`
-    )
-  }
+  const auth = 'auth' in context ? (context.auth as any) : undefined
+  const isAuthenticated = auth ? await auth.check() : false
 
-  const auth = context.auth as any
-  const isAuthenticated = await auth.check()
-
-  if (!isAuthenticated) {
-    return false
-  }
-
-  if (abilities) {
-    if (!('bouncer' in context)) {
+  if (!rules || rules.length === 0) {
+    if (!auth) {
       throw new UnavailableFeatureError(
-        `You tried to use Authorization features (Bouncer) but bouncer is not available in HttpContext.`
+        `You tried to use Authentication features but no authenticator is available in HttpContext.`
       )
     }
 
-    const bouncer = context.bouncer as Bouncer<any>
-    for (const ability of abilities) {
-      if (await bouncer.denies(ability)) {
-        return false
-      }
+    return isAuthenticated
+  }
+
+  if (!('bouncer' in context)) {
+    throw new UnavailableFeatureError(
+      `You tried to use Authorization features (Bouncer) but bouncer is not available in HttpContext.`
+    )
+  }
+
+  const bouncer = context.bouncer as Bouncer<any>
+
+  for (const rule of rules) {
+    let denied: boolean
+
+    if (isPolicyRule(rule)) {
+      denied = await bouncer.with(rule.policy).denies(rule.method as never, root)
+    } else if (typeof rule === 'string' || isAbility(rule)) {
+      denied = await bouncer.denies(rule as BouncerAbility<any>, root)
+    } else {
+      throw new TypeError(
+        `Invalid authorization requirement passed to @Authorized. Expected a Bouncer ability, the name of a pre-registered ability or a policy class with a method name.`
+      )
+    }
+
+    if (denied) {
+      return false
     }
   }
 

--- a/packages/graphql/src/decorators/authorized.ts
+++ b/packages/graphql/src/decorators/authorized.ts
@@ -1,0 +1,60 @@
+import { Authorized as BaseAuthorized } from 'type-graphql'
+import { type BouncerAbility, type GetPolicyMethods } from '@adonisjs/bouncer/types'
+import { type Constructor } from '@adonisjs/core/types/common'
+import { type AuthorizationRule } from '../types.js'
+
+type MethodPropClassDecorator = PropertyDecorator & MethodDecorator & ClassDecorator
+
+/**
+ * Restricts the target to authenticated users.
+ */
+export function Authorized(): MethodPropClassDecorator
+
+/**
+ * Restricts the target using Bouncer abilities.
+ * The user is authorized only if all abilities pass.
+ *
+ * When used on a field or a field resolver, the parent object is passed
+ * to the ability after the user.
+ *
+ * @example
+ *
+ * \@Authorized([abilities.editRecipe])
+ */
+export function Authorized(abilities: readonly BouncerAbility<any>[]): MethodPropClassDecorator
+
+/**
+ * Restricts the target using Bouncer abilities.
+ * The user is authorized only if all abilities pass.
+ *
+ * When used on a field or a field resolver, the parent object is passed
+ * to the ability after the user.
+ *
+ * @example
+ *
+ * \@Authorized(abilities.editRecipe, abilities.isAdmin)
+ */
+export function Authorized(...abilities: readonly BouncerAbility<any>[]): MethodPropClassDecorator
+
+/**
+ * Restricts the target using a Bouncer policy method.
+ *
+ * When used on a field or a field resolver, the parent object is passed
+ * to the policy method after the user.
+ *
+ * @example
+ *
+ * \@Authorized(RecipePolicy, 'edit')
+ */
+export function Authorized<Policy extends Constructor<any>>(
+  policy: Policy,
+  method: GetPolicyMethods<any, InstanceType<Policy>>
+): MethodPropClassDecorator
+
+export function Authorized(...args: any[]): MethodPropClassDecorator {
+  if (args.length === 2 && typeof args[0] === 'function' && typeof args[1] === 'string') {
+    return BaseAuthorized<AuthorizationRule>([{ policy: args[0], method: args[1] }])
+  }
+
+  return BaseAuthorized<AuthorizationRule>(...args)
+}

--- a/packages/graphql/src/drivers/yoga_driver.ts
+++ b/packages/graphql/src/drivers/yoga_driver.ts
@@ -65,13 +65,35 @@ export class YogaDriver<
       requestHeaders.push([key, value as string])
     }
 
+    const contentType = ctx.request.header('content-type') || ''
+    const isMultipart = contentType.startsWith('multipart/form-data')
+
+    const init: RequestInit & { duplex?: 'half' } = {
+      method: ctx.request.method(),
+      headers: requestHeaders,
+    }
+
+    if (isMultipart) {
+      /**
+       * The bodyparser does not buffer multipart bodies (autoProcess/processManually),
+       * so `request.raw()` is null. Stream the untouched Node request into Yoga instead
+       * so it can parse the graphql-multipart-request spec (operations/map/files).
+       */
+      if (ctx.request.request.readableEnded) {
+        throw new RuntimeException(
+          `Cannot handle the multipart GraphQL request as its body has already been consumed by the bodyparser. Add "${ctx.request.url()}" to "multipart.processManually" in "config/bodyparser.ts" to enable file uploads.`
+        )
+      }
+
+      init.body = ctx.request.request as unknown as BodyInit
+      init.duplex = 'half'
+    } else {
+      init.body = ctx.request.raw()
+    }
+
     const { status, headers, body } = await this.yoga.fetch(
       ctx.request.request.url,
-      {
-        method: ctx.request.method(),
-        headers: requestHeaders,
-        body: ctx.request.raw(),
-      },
+      init,
       ctx as TServerContext
     )
 

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -9,6 +9,8 @@ import { type GraphQLSchema } from 'graphql'
 import { type ConfigProvider, type LoggersList } from '@adonisjs/core/types'
 import { type Repeater } from '@graphql-yoga/subscription'
 import { type Logger } from '@adonisjs/core/logger'
+import { type BouncerAbility } from '@adonisjs/bouncer/types'
+import { type Constructor } from '@adonisjs/core/types/common'
 
 export interface GraphQLConfig<
   KnownDriver extends GraphQLDriverContract,
@@ -87,6 +89,23 @@ export type ResolverData = BaseResolverData<HttpContext>
 export interface GraphQLMiddleware {
   use(action: ResolverData, next: NextFn): Promise<any>
 }
+
+/**
+ * Reference to a Bouncer policy method collected by the `@Authorized`
+ * decorator and evaluated by the auth checker using
+ * `bouncer.with(policy).denies(method, root)`.
+ */
+export interface PolicyAuthorizationRule {
+  policy: Constructor<any>
+  method: string
+}
+
+/**
+ * Authorization requirement accepted by the `@Authorized` decorator.
+ * Either a Bouncer ability, the name of an ability pre-registered on the
+ * Bouncer instance, or a reference to a policy method.
+ */
+export type AuthorizationRule = BouncerAbility<any> | PolicyAuthorizationRule | string
 
 export interface GraphQLDriverContract {
   start(schema: GraphQLSchema): Promise<void>

--- a/packages/graphql/tests/auth_checker.spec.ts
+++ b/packages/graphql/tests/auth_checker.spec.ts
@@ -88,4 +88,117 @@ test.group('AuthChecker', () => {
       )
     ).resolves.toBe(true)
   })
+
+  test('passes the root object to abilities', async ({ expect }) => {
+    const user = { id: 1 }
+    const context = {
+      auth: { check: () => true },
+      bouncer: new Bouncer(user),
+    }
+    const editRecipe = Bouncer.ability(
+      (u: { id: number }, recipe: { authorId: number }) => u.id === recipe.authorId
+    )
+
+    await expect(checker({ context, root: { authorId: 1 } }, [editRecipe])).resolves.toBe(true)
+    await expect(checker({ context, root: { authorId: 2 } }, [editRecipe])).resolves.toBe(false)
+  })
+
+  test('authorizes using a policy method and passes the root object', async ({ expect }) => {
+    class RecipePolicy {
+      edit(u: { id: number }, recipe: { authorId: number }) {
+        return u.id === recipe.authorId
+      }
+    }
+
+    const context = {
+      auth: { check: () => true },
+      bouncer: new Bouncer({ id: 1 }),
+    }
+
+    await expect(
+      checker({ context, root: { authorId: 1 } }, [{ policy: RecipePolicy, method: 'edit' }])
+    ).resolves.toBe(true)
+    await expect(
+      checker({ context, root: { authorId: 2 } }, [{ policy: RecipePolicy, method: 'edit' }])
+    ).resolves.toBe(false)
+  })
+
+  test('lets bouncer decide for guests when rules are provided', async ({ expect }) => {
+    const context = {
+      auth: { check: () => false },
+      bouncer: new Bouncer(() => null),
+    }
+
+    await expect(
+      checker({ context }, [Bouncer.ability({ allowGuest: true }, () => true)])
+    ).resolves.toBe(true)
+    await expect(checker({ context }, [Bouncer.ability(() => true)])).resolves.toBe(false)
+  })
+
+  test('evaluates guest rules when no authenticator is available', async ({ expect }) => {
+    const context = {
+      bouncer: new Bouncer(() => null),
+    }
+
+    await expect(
+      checker({ context }, [Bouncer.ability({ allowGuest: true }, () => true)])
+    ).resolves.toBe(true)
+    await expect(checker({ context }, [Bouncer.ability(() => true)])).resolves.toBe(false)
+  })
+
+  test('requires all rules to pass', async ({ expect }) => {
+    class RecipePolicy {
+      edit(u: { id: number }, recipe: { authorId: number }) {
+        return u.id === recipe.authorId
+      }
+    }
+
+    const allows = Bouncer.ability(() => true)
+    const denies = Bouncer.ability(() => false)
+    const context = {
+      auth: { check: () => true },
+      bouncer: new Bouncer({ id: 1 }),
+    }
+
+    await expect(checker({ context }, [allows, denies])).resolves.toBe(false)
+    await expect(checker({ context }, [allows, allows])).resolves.toBe(true)
+    await expect(
+      checker({ context, root: { authorId: 1 } }, [
+        allows,
+        { policy: RecipePolicy, method: 'edit' },
+      ])
+    ).resolves.toBe(true)
+    await expect(
+      checker({ context, root: { authorId: 2 } }, [
+        allows,
+        { policy: RecipePolicy, method: 'edit' },
+      ])
+    ).resolves.toBe(false)
+  })
+
+  test('resolves pre-registered ability names and passes the root object', async ({ expect }) => {
+    const abilities = {
+      editRecipe: Bouncer.ability(
+        (u: { id: number }, recipe: { authorId: number }) => u.id === recipe.authorId
+      ),
+    }
+    const context = {
+      auth: { check: () => true },
+      bouncer: new Bouncer({ id: 1 }, abilities),
+    }
+
+    await expect(checker({ context, root: { authorId: 1 } }, ['editRecipe'])).resolves.toBe(true)
+    await expect(checker({ context, root: { authorId: 2 } }, ['editRecipe'])).resolves.toBe(false)
+  })
+
+  test('throws when an invalid rule is provided', async ({ expect }) => {
+    const context = {
+      auth: { check: () => true },
+      bouncer: new Bouncer({ id: 1 }),
+    }
+
+    await expect(checker({ context }, [42])).rejects.toThrow(
+      /Invalid authorization requirement passed to @Authorized/
+    )
+  })
 })

--- a/packages/graphql/tests/authorized.spec.ts
+++ b/packages/graphql/tests/authorized.spec.ts
@@ -1,0 +1,238 @@
+import { test } from '@japa/runner'
+import { graphql, type GraphQLSchema } from 'graphql'
+import { buildSchema, Field, FieldResolver, ObjectType, Query, Resolver, Root } from 'type-graphql'
+import { Bouncer, allowGuest, BasePolicy } from '@adonisjs/bouncer'
+import { Authorized } from '../src/decorators/authorized.js'
+import { authChecker } from '../src/auth_checker.js'
+
+interface TestUser {
+  id: number
+  isAdmin?: boolean
+}
+
+class RecipePolicy extends BasePolicy {
+  view(user: TestUser, recipe: { authorId: number }) {
+    return user.id === recipe.authorId
+  }
+
+  @allowGuest()
+  list() {
+    return true
+  }
+}
+
+const isAuthor = Bouncer.ability(
+  (user: TestUser, recipe: { authorId: number }) => user.id === recipe.authorId
+)
+
+const isAdmin = Bouncer.ability((user: TestUser) => user.isAdmin === true)
+
+let capturedRoot: unknown = 'sentinel'
+const captureRoot = Bouncer.ability({ allowGuest: true }, (_user: TestUser | null, root: any) => {
+  capturedRoot = root
+  return true
+})
+
+@ObjectType()
+class Recipe {
+  declare authorId: number
+
+  @Field()
+  declare title: string
+
+  @Field()
+  @Authorized(RecipePolicy, 'view')
+  declare secret: string
+
+  @Field()
+  @Authorized([isAuthor])
+  declare notes: string
+}
+
+@Resolver()
+class RecipeResolver {
+  @Query(() => Recipe)
+  recipe() {
+    return Object.assign(new Recipe(), {
+      authorId: 1,
+      title: 'Ratatouille',
+      secret: 'thyme',
+      notes: 'simmer slowly',
+    })
+  }
+
+  @Query(() => String)
+  @Authorized(RecipePolicy, 'list')
+  recipeCount() {
+    return '42'
+  }
+
+  @Query(() => String)
+  @Authorized([captureRoot])
+  rootProbe() {
+    return 'probed'
+  }
+}
+
+@Resolver(() => Recipe)
+class RecipeFieldsResolver {
+  @FieldResolver(() => String)
+  @Authorized([isAuthor])
+  computedSecret(@Root() recipe: Recipe) {
+    return `${recipe.title} secret`
+  }
+}
+
+@Resolver()
+@Authorized([isAdmin])
+class AdminResolver {
+  @Query(() => String)
+  adminReport() {
+    return 'report'
+  }
+
+  @Query(() => String)
+  @Authorized()
+  memberReport() {
+    return 'member report'
+  }
+}
+
+function createContext(user: TestUser | null) {
+  return {
+    auth: {
+      check: async () => user !== null,
+      user,
+    },
+    bouncer: new Bouncer(() => user),
+  }
+}
+
+let schema: GraphQLSchema
+
+test.group('Authorized decorator', (group) => {
+  group.setup(async () => {
+    schema = await buildSchema({
+      resolvers: [RecipeResolver, RecipeFieldsResolver, AdminResolver],
+      authChecker,
+    })
+  })
+
+  test('allows policy protected fields when the policy passes', async ({ expect }) => {
+    const result = await graphql({
+      schema,
+      source: '{ recipe { title secret } }',
+      contextValue: createContext({ id: 1 }),
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.recipe).toEqual({ title: 'Ratatouille', secret: 'thyme' })
+  })
+
+  test('rejects policy protected fields when the policy denies', async ({ expect }) => {
+    const result = await graphql({
+      schema,
+      source: '{ recipe { title secret } }',
+      contextValue: createContext({ id: 2 }),
+    })
+
+    expect(result.errors).toBeDefined()
+    expect(result.errors?.[0]?.path).toEqual(['recipe', 'secret'])
+  })
+
+  test('passes the parent object to abilities on fields', async ({ expect }) => {
+    const allowed = await graphql({
+      schema,
+      source: '{ recipe { notes } }',
+      contextValue: createContext({ id: 1 }),
+    })
+    expect(allowed.errors).toBeUndefined()
+    expect(allowed.data?.recipe).toEqual({ notes: 'simmer slowly' })
+
+    const denied = await graphql({
+      schema,
+      source: '{ recipe { notes } }',
+      contextValue: createContext({ id: 2 }),
+    })
+    expect(denied.errors).toBeDefined()
+  })
+
+  test('allows guests on policy methods marked with allowGuest', async ({ expect }) => {
+    const result = await graphql({
+      schema,
+      source: '{ recipeCount }',
+      contextValue: createContext(null),
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.recipeCount).toBe('42')
+  })
+
+  test('rejects guests on policy methods without allowGuest', async ({ expect }) => {
+    const result = await graphql({
+      schema,
+      source: '{ recipe { secret } }',
+      contextValue: createContext(null),
+    })
+
+    expect(result.errors).toBeDefined()
+  })
+
+  test('passes the parent object to abilities on field resolvers', async ({ expect }) => {
+    const allowed = await graphql({
+      schema,
+      source: '{ recipe { computedSecret } }',
+      contextValue: createContext({ id: 1 }),
+    })
+    expect(allowed.errors).toBeUndefined()
+    expect(allowed.data?.recipe).toEqual({ computedSecret: 'Ratatouille secret' })
+
+    const denied = await graphql({
+      schema,
+      source: '{ recipe { computedSecret } }',
+      contextValue: createContext({ id: 2 }),
+    })
+    expect(denied.errors).toBeDefined()
+  })
+
+  test('receives undefined instead of a parent object on queries', async ({ expect }) => {
+    capturedRoot = 'sentinel'
+
+    const result = await graphql({
+      schema,
+      source: '{ rootProbe }',
+      contextValue: createContext({ id: 1 }),
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(capturedRoot).toBeUndefined()
+  })
+
+  test('applies class level rules to every operation of the resolver', async ({ expect }) => {
+    const denied = await graphql({
+      schema,
+      source: '{ adminReport }',
+      contextValue: createContext({ id: 1 }),
+    })
+    expect(denied.errors).toBeDefined()
+
+    const allowed = await graphql({
+      schema,
+      source: '{ adminReport }',
+      contextValue: createContext({ id: 1, isAdmin: true }),
+    })
+    expect(allowed.errors).toBeUndefined()
+    expect(allowed.data?.adminReport).toBe('report')
+  })
+
+  test('method level rules replace class level rules', async ({ expect }) => {
+    const result = await graphql({
+      schema,
+      source: '{ memberReport }',
+      contextValue: createContext({ id: 1 }),
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.memberReport).toBe('member report')
+  })
+})

--- a/packages/graphql/tests/e2e/drivers/yoga_driver.spec.ts
+++ b/packages/graphql/tests/e2e/drivers/yoga_driver.spec.ts
@@ -1,11 +1,13 @@
 import { test } from '@japa/runner'
 import { setupApp } from '../../helpers.js'
 import { defineConfig, drivers } from '../../../src/define_config.js'
+import { defineConfig as defineBodyParserConfig } from '@adonisjs/core/bodyparser'
 import { ApolloClient, ApolloLink, gql, HttpLink, InMemoryCache } from '@apollo/client'
 import { OperationTypeNode } from 'graphql'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'
 import { TestResolver } from '../../fixtures/test_resolver.js'
+import { UploadResolver } from '../../fixtures/upload_resolver.js'
 import WebSocket from 'ws'
 
 export function setupApolloClient() {
@@ -36,7 +38,7 @@ export function setupApolloClient() {
   return { apollo, wsLink, httpLink }
 }
 
-async function setupYogaApp() {
+async function setupYogaApp(bodyparser?: ReturnType<typeof defineBodyParserConfig>) {
   return setupApp(
     (factory) =>
       factory.merge({
@@ -47,13 +49,24 @@ async function setupYogaApp() {
             pubSub: drivers.pubsub.native(),
             subscription: drivers.subscription.websocket({ path: '/graphql' }),
           }),
+          bodyparser:
+            bodyparser ??
+            defineBodyParserConfig({
+              multipart: {
+                autoProcess: true,
+                processManually: ['/graphql'],
+              },
+            }),
         },
       }),
     (app) => {
       app.booted(async () => {
         const graphql = await app.container.make('graphql')
         const router = await app.container.make('router')
-        graphql.resolvers([() => Promise.resolve({ default: TestResolver })])
+        graphql.resolvers([
+          () => Promise.resolve({ default: TestResolver }),
+          () => Promise.resolve({ default: UploadResolver }),
+        ])
         graphql.registerRoute(router)
       })
     }
@@ -101,6 +114,61 @@ test.group('YogaDriver', () => {
 
     expect(data).toMatchObject({ testMutation: true })
   }).skip(false)
+
+  function buildUploadForm() {
+    const form = new FormData()
+    form.append(
+      'operations',
+      JSON.stringify({
+        query: 'mutation TestUpload($file: File!) { testUpload(file: $file) }',
+        variables: { file: null },
+      })
+    )
+    form.append('map', JSON.stringify({ '0': ['variables.file'] }))
+    form.append('0', new File(['Hello Yoga'], 'hello.txt', { type: 'text/plain' }))
+    return form
+  }
+
+  test('should support file uploads', async ({ expect, cleanup }) => {
+    const { app } = await setupYogaApp()
+    cleanup(async () => {
+      await app.terminate()
+    })
+
+    const response = await fetch('http://localhost:3333/graphql', {
+      method: 'POST',
+      body: buildUploadForm(),
+    })
+
+    const result = (await response.json()) as any
+
+    expect(response.status).toBe(200)
+    expect(result).toMatchObject({ data: { testUpload: 'hello.txt:Hello Yoga' } })
+  })
+
+  test('should fail with an actionable error when the bodyparser consumed the multipart body', async ({
+    expect,
+    cleanup,
+  }) => {
+    const { app } = await setupYogaApp(
+      defineBodyParserConfig({
+        multipart: {
+          autoProcess: true,
+        },
+      })
+    )
+    cleanup(async () => {
+      await app.terminate()
+    })
+
+    const response = await fetch('http://localhost:3333/graphql', {
+      method: 'POST',
+      body: buildUploadForm(),
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.text()).toContain('processManually')
+  })
 
   test('should support subscriptions over Websockets', async ({ expect, cleanup }) => {
     const { app } = await setupYogaApp()

--- a/packages/graphql/tests/fixtures/upload_resolver.ts
+++ b/packages/graphql/tests/fixtures/upload_resolver.ts
@@ -1,0 +1,15 @@
+import { GraphQLScalarType } from 'graphql'
+import { Arg, Mutation, Resolver } from '../../index.js'
+
+export const FileScalar = new GraphQLScalarType({
+  name: 'File',
+  description: 'The `File` scalar type represents a file upload.',
+})
+
+@Resolver()
+export class UploadResolver {
+  @Mutation(() => String)
+  async testUpload(@Arg('file', () => FileScalar) file: File) {
+    return `${file.name}:${await file.text()}`
+  }
+}

--- a/playgrounds/graphql/app/graphql/resolvers/recipe_resolver.ts
+++ b/playgrounds/graphql/app/graphql/resolvers/recipe_resolver.ts
@@ -5,6 +5,7 @@ import {
   Arg,
   Args,
   ArgsType,
+  Authorized,
   Field,
   InputType,
   Int,
@@ -15,6 +16,7 @@ import {
 } from '@foadonis/graphql'
 import PerformanceLoggerMiddleware from '#graphql/middlewares/performance_logger_middleware'
 import { TestService } from '#services/test_service'
+import RecipePolicy from '#policies/recipe_policy'
 
 @ArgsType()
 class RecipeArgs {
@@ -66,6 +68,7 @@ export default class RecipeResolver {
   }
 
   @Mutation(() => Boolean)
+  @Authorized(RecipePolicy, 'delete')
   async removeRecipe(@Arg('id') id: number) {
     const recipe = await Recipe.find(id)
 

--- a/playgrounds/graphql/app/policies/recipe_policy.ts
+++ b/playgrounds/graphql/app/policies/recipe_policy.ts
@@ -1,0 +1,14 @@
+import User from '#models/user'
+import Recipe from '#models/recipe'
+import { BasePolicy } from '@adonisjs/bouncer'
+import { AuthorizerResponse } from '@adonisjs/bouncer/types'
+
+export default class RecipePolicy extends BasePolicy {
+  /**
+   * Delete the following method to start from
+   * scratch
+   */
+  delete(_user: User, _recipe?: Recipe): AuthorizerResponse {
+    return true
+  }
+}


### PR DESCRIPTION
## 📝 Description

This PR extends the `@Authorized` decorator of `@foadonis/graphql` to support Bouncer policies and fully delegates authorization to Bouncer. It also fixes file uploads with the Yoga driver, which were broken because multipart bodies never reached GraphQL Yoga.

## 🔄 What's new

- ✨ New feature (non-breaking change which adds functionality)
- 🐛 Bug fix (non-breaking change which fixes an issue)
- 📚 Documentation update
- ✅ Test additions or updates

## 📦 Package(s) Affected

- [x] @foadonis/graphql
- [x] Documentation

## 🔍 What Does This PR Do?

### Bouncer policies support (`feat`)

- `@Authorized` now accepts a Bouncer policy with a method name: `@Authorized(RecipePolicy, 'edit')`, with full type-safety on the method name via `GetPolicyMethods`.
- When used on a field or a field resolver, the parent object (`root`) is now passed to abilities and policy methods after the user, enabling per-object authorization.
- Authorization is now fully delegated to Bouncer: the auth checker no longer short-circuits unauthenticated users, so `allowGuest` abilities and policy methods are evaluated for guests. A bare `@Authorized()` still only checks authentication.
- Invalid arguments passed to `@Authorized` now throw a descriptive `TypeError`.

### Yoga driver file uploads (`fix`)

- The bodyparser never buffers multipart bodies, so `request.raw()` returned `null` and uploads following the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec) always failed.
- The Yoga driver now detects `multipart/form-data` requests and streams the untouched Node request into Yoga (`duplex: 'half'`) so it can parse `operations`/`map`/files itself.
- If the body was already consumed by the bodyparser, a `RuntimeException` is thrown with instructions to add the GraphQL endpoint to `multipart.processManually` in `config/bodyparser.ts`.

Documentation has been updated accordingly (`graphql/authorization` and `graphql/drivers/yoga`), and the playground includes a policy-protected field example.

## 🧪 Testing

- `pnpm --filter @foadonis/graphql test` runs the new unit tests (`tests/authorized.spec.ts`, `tests/auth_checker.spec.ts`) and the e2e Yoga driver tests covering multipart file uploads (`tests/e2e/drivers/yoga_driver.spec.ts`).
- Manually: in the `playgrounds/graphql` app, query the `Recipe` field protected by `@Authorized(RecipePolicy, ...)` and upload a file through the multipart spec against the Yoga endpoint.

## 💡 Additional Notes

Guest evaluation is a deliberate behavior change: previously unauthenticated users were always denied before Bouncer ran. It is released as a `minor` since `allowGuest` abilities and policies now behave as documented by Bouncer, and abilities without `allowGuest` still deny guests.

## 🔄 Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does not introduce breaking changes

## 📋 Requirements

- [x] I have read and follow the [contributing guidelines](https://github.com/FriendsOfAdonis/FriendsOfAdonis/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added changesets that reflects my changes
- [x] I have added automated tests

## ✨ AI Usage

- [x] I have used generative AI to write the pull-request
