### PR TITLE
fix(openapi): deduplicate auto-discovered path parameters

### DIFF
--- a/.changeset/openapi-path-params-deduplicate.md
+++ b/.changeset/openapi-path-params-deduplicate.md
@@ -1,0 +1,5 @@
+---
+"@foadonis/openapi": patch
+---
+
+Deduplicate auto-discovered path parameters so they no longer accumulate across `buildDocument()` calls. A path parameter already registered — by a previous router scan or a user-provided `@ApiParam` — is now skipped instead of being appended again.

--- a/packages/openapi/src/loader.ts
+++ b/packages/openapi/src/loader.ts
@@ -70,6 +70,16 @@ export class RouterLoader {
     )
 
     for (const param of params) {
+      // `mergeMetadata` concatenates arrays, and the metadata registry lives for the whole
+      // process, so re-scanning the router on every `buildDocument()` call (dev/test) would
+      // otherwise append a duplicate path parameter each time. Skip params already registered
+      // — whether by a previous scan or a user-provided `@ApiParam` — to stay idempotent.
+      const existingParams = OperationParameterMetadataStorage.getMetadata(
+        target.prototype,
+        propertyKey
+      )
+      if (existingParams.some((p) => p.in === 'path' && p.name === param)) continue
+
       OperationParameterMetadataStorage.mergeMetadata(
         target.prototype,
         [{ in: 'path', type: 'string', name: param, required: true }],

--- a/packages/openapi/tests/loader.spec.ts
+++ b/packages/openapi/tests/loader.spec.ts
@@ -2,6 +2,15 @@ import { test } from '@japa/runner'
 import type { RouteJSON } from '@adonisjs/core/types/http'
 import { RouterLoader } from '../src/loader.ts'
 import { OperationParameterMetadataStorage } from '@martin.xyz/openapi-decorators/metadata'
+import { ApiParam } from '@martin.xyz/openapi-decorators/decorators'
+
+function createLoader() {
+  return new RouterLoader(
+    {} as unknown as ConstructorParameters<typeof RouterLoader>[0],
+    console as unknown as ConstructorParameters<typeof RouterLoader>[1],
+    () => []
+  )
+}
 
 test.group('RouterLoader', () => {
   test('marks auto-discovered path parameters as required', async ({ assert }) => {
@@ -21,13 +30,7 @@ test.group('RouterLoader', () => {
       ],
     } as unknown as RouteJSON
 
-    const loader = new RouterLoader(
-      {} as unknown as ConstructorParameters<typeof RouterLoader>[0],
-      console as unknown as ConstructorParameters<typeof RouterLoader>[1],
-      () => []
-    )
-
-    await loader.loadRouteController(route)
+    await createLoader().loadRouteController(route)
 
     const parameters = OperationParameterMetadataStorage.getMetadata(
       DevicesController.prototype,
@@ -41,6 +44,79 @@ test.group('RouterLoader', () => {
       type: 'string',
       name: 'id',
       required: true,
+    })
+  })
+
+  test('does not duplicate path parameters across multiple loads', async ({ assert }) => {
+    class DevicesController {
+      show() {}
+    }
+
+    const route = {
+      pattern: '/api/devices/:id',
+      methods: ['GET', 'HEAD'],
+      handler: { reference: [DevicesController, 'show'] },
+      tokens: [
+        { type: 0, val: 'api' },
+        { type: 0, val: 'devices' },
+        { type: 1, val: 'id' },
+      ],
+    } as unknown as RouteJSON
+
+    // The metadata registry lives for the whole process and is re-scanned on every
+    // `buildDocument()` call outside production, so loading the same route more than once
+    // must stay idempotent instead of appending a duplicate parameter each time.
+    const loader = createLoader()
+    await loader.loadRouteController(route)
+    await loader.loadRouteController(route)
+    await loader.loadRouteController(route)
+
+    const parameters = OperationParameterMetadataStorage.getMetadata(
+      DevicesController.prototype,
+      'show'
+    )
+
+    assert.lengthOf(parameters, 1)
+    assert.deepEqual(parameters[0], {
+      in: 'path',
+      type: 'string',
+      name: 'id',
+      required: true,
+    })
+  })
+
+  test('does not duplicate a path parameter already declared with @ApiParam', async ({
+    assert,
+  }) => {
+    class DevicesController {
+      @ApiParam({ name: 'id', description: 'The device identifier' })
+      show() {}
+    }
+
+    const route = {
+      pattern: '/api/devices/:id',
+      methods: ['GET', 'HEAD'],
+      handler: { reference: [DevicesController, 'show'] },
+      tokens: [
+        { type: 0, val: 'api' },
+        { type: 0, val: 'devices' },
+        { type: 1, val: 'id' },
+      ],
+    } as unknown as RouteJSON
+
+    await createLoader().loadRouteController(route)
+
+    const parameters = OperationParameterMetadataStorage.getMetadata(
+      DevicesController.prototype,
+      'show'
+    )
+
+    // The user-defined declaration wins; auto-discovery must not append a duplicate.
+    assert.lengthOf(parameters, 1)
+    assert.deepEqual(parameters[0], {
+      in: 'path',
+      name: 'id',
+      description: 'The device identifier',
     })
   })
 })


### PR DESCRIPTION
Closes #142

## Problem

`RouterLoader.loadRouteController` registers auto-discovered path parameters with `OperationParameterMetadataStorage.mergeMetadata(...)`. `mergeMetadata` deep-merges, and `deepmerge` **concatenates** arrays into the process-lifetime metadata registry keyed on the controller prototype. The registry is never cleared between `buildDocument()` calls.

Outside production `buildDocument()` doesn't memoize, so it re-runs `load()` on every call and appends **one more** duplicate `{ in: 'path', name }` entry per path param. After N builds the emitted OpenAPI document carries N duplicate copies of each path parameter — visible to any test that asserts on the spec or any dev server that regenerates on reload.

The sibling `OperationMetadataStorage` write just above already avoids this by reading with `getMetadata` and overwriting with `defineMetadata`; path params were the only per-route metadata still merged with the accumulating call.

## Fix

Make the path-param merge idempotent by deduping on `(in, name)` before merging — this is the approach [suggested in the issue](https://github.com/FriendsOfAdonis/FriendsOfAdonis/issues/142) and approved by @kerwanp:

```ts
for (const param of params) {
  const existingParams = OperationParameterMetadataStorage.getMetadata(target.prototype, propertyKey)
  if (existingParams.some((p) => p.in === 'path' && p.name === param)) continue

  OperationParameterMetadataStorage.mergeMetadata(
    target.prototype,
    [{ in: 'path', type: 'string', name: param, required: true }],
    propertyKey
  )
}
```

Because the check also matches parameters registered via `@ApiParam`, this additionally fixes the related duplication reported in the issue comments when a path parameter is declared manually (e.g. to add a description) — the user-defined declaration now wins and auto-discovery no longer appends a duplicate on top of it.

## Tests

Added two regression tests to `packages/openapi/tests/loader.spec.ts`:

- `does not duplicate path parameters across multiple loads` — loads the same route three times and asserts the parameter is registered exactly once.
- `does not duplicate a path parameter already declared with @ApiParam` — asserts the manual declaration is preserved without a duplicate.

Verification: `loader.spec.ts` 3 passed · full `@foadonis/openapi` suite 36 passed · `tsc --noEmit` clean · `oxlint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
